### PR TITLE
release 0.1.3

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,6 +1,6 @@
 app:
   image:
-    tag: "0.1.2"
+    tag: "0.1.3"
 
 ingress:
   enabled: true


### PR DESCRIPTION
Needed to disable a prematurely implemented cache so we can see the newest data properly.