### PR TITLE
Release 1.0.0

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,6 +1,6 @@
 app:
   image:
-    tag: "0.1.2"
+    tag: "1.0.0"
 
 ingress:
   enabled: true


### PR DESCRIPTION
With the errata from our soft launch out of the way, this is our first "stable" release.