### PR TITLE
Update Hologit reference to v2.0.3 to match image tag

### DIFF
--- a/.holo/sources/choose-native-plants.toml
+++ b/.holo/sources/choose-native-plants.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/pa-wildflower-selector"
-ref = "refs/tags/v1.1.0"
+ref = "refs/tags/v2.0.3"


### PR DESCRIPTION
This pull request updates the reference for the `choose-native-plants` Holo source to use the latest version of the repository.

Version update:

* [`.holo/sources/choose-native-plants.toml`](diffhunk://#diff-ecd49b71bdd84eb9b7fa6ca70d5dc99e6877213dee0044135baddfd62099f063L3-R3): Updated the `ref` field from `refs/tags/v1.1.0` to `refs/tags/v2.0.3` to point to the latest version of the source repository.