### PR TITLE
Fix PVC name to match existing production PVC

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -56,7 +56,7 @@ resources:
 
 # Use existing resources instead of creating new ones
 existingPVCs:
-  appImages: "choose-native-plants-app-images-v2"
+  appImages: "choose-native-plants-app-images"
   mongoData: "choose-native-plants-mongo-data"
 
 # Horizontal Pod Autoscaling configuration


### PR DESCRIPTION
This pull request makes a small adjustment to the `resources:` section in the `choose-native-plants/release-values.yaml` file. The change updates the `appImages` value to reference the correct existing PersistentVolumeClaim (PVC).

* [`choose-native-plants/release-values.yaml`](diffhunk://#diff-5792d0f10a00ff40bd8f2ab47da2c3b64d7f0a2737107b580e9ff93d6f9c356aL59-R59): Updated the `appImages` PVC from `"choose-native-plants-app-images-v2"` to `"choose-native-plants-app-images"`.
![image](https://github.com/user-attachments/assets/c95bf967-0554-4f30-adb0-ae8fa8ff1c6b)
