### PR TITLE
fix(choose-native-plants): increase memory limits and add rate limiting

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -8,7 +8,7 @@ app:
   # Duplicating these variables causes patch errors in the GitOps deployment process
   env:
     - name: NODE_OPTIONS
-      value: "--openssl-legacy-provider --max-old-space-size=768"
+      value: "--openssl-legacy-provider --max-old-space-size=3072"
   envFrom:
     - secretRef:
         name: app
@@ -22,9 +22,9 @@ app:
 # Resource settings for the application
 resources:
   limits:
-    memory: 1Gi
+    memory: 4Gi
   requests:
-    memory: 512Mi
+    memory: 1Gi
 
 # Horizontal Pod Autoscaling configuration
 autoscaling:
@@ -39,6 +39,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/limit-rps: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
   hosts:
     - host: choose-native-plants.live.k8s.phl.io
       paths: [ '/' ]


### PR DESCRIPTION
## Summary

- Increases Node.js heap from `--max-old-space-size=768` to `3072` to match the cfp-sandbox-cluster config (which has been stable with this setting)
- Increases container memory limit from `1Gi` to `4Gi` and request from `512Mi` to `1Gi`
- Adds nginx ingress rate limiting (20 rps / 20 connections per IP) to mitigate bot scanner traffic that was causing liveness probe timeouts

## Background

App v2.2.8 added `@xenova/transformers` for ML-based semantic plant search. At startup it loads embeddings for ~5,800 plants, which requires significantly more heap than the old v2.0.7 baseline. The pod was crash-looping ~5x/day on prod because the 768MB heap limit caused V8 GC pressure that stalled the event loop long enough to fail the liveness probe. The sandbox cluster has been running with `4Gi` / `3072` heap for weeks with only rare restarts (all attributable to bot scanner traffic, addressed by the rate limiting here).

## Test plan

- [ ] Confirm pod restarts stop after deploy
- [ ] Confirm `choosenativeplants.com` loads normally post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)