### PR TITLE
Prepare live Choose Native Plants sync configuration

### DIFF
--- a/choose-native-plants/README.md
+++ b/choose-native-plants/README.md
@@ -26,11 +26,11 @@ Ensure that the version in both files match (with the toml file using the 'v' pr
 
 ```powershell
 # Create a regular Kubernetes secret YAML file
-# Example for PAC API credentials
-kubectl create secret generic pac-api --from-literal=PAC_API_BASE_URL=https://app.plantagents.org --from-literal=PAC_API_KEY=your-api-key --dry-run=client -o yaml > pac-api-secret.yaml
+# PlantAgents Neon read-only connection
+kubectl create secret generic plantagents-postgres --from-literal=PLANTAGENTS_DATABASE_URL='postgresql://...' --dry-run=client -o yaml > plantagents-postgres-secret.yaml
 
 # Seal the secret
-kubeseal --cert https://sealed-secrets.live.k8s.phl.io/v1/cert.pem --namespace choose-native-plants -f pac-api-secret.yaml -w cfp-live-cluster/choose-native-plants.secrets/pac-api.yaml
+kubeseal --cert https://sealed-secrets.live.k8s.phl.io/v1/cert.pem --namespace choose-native-plants -f plantagents-postgres-secret.yaml -w cfp-live-cluster/choose-native-plants.secrets/plantagents-postgres.yaml
 ```
 
 4. Commit and push the changes to the repository:
@@ -54,6 +54,17 @@ git push origin main
   - https://www.choosenativeplants.com/
 
 ## Managing the Application
+
+### PlantAgents nursery data sync
+
+After the read-only secret above is sealed and sandbox acceptance passes, set `plantagentsSync.enabled: true`. Create the first run manually and inspect its JSON summary:
+
+```powershell
+kubectl create job --from=cronjob/choose-native-plants-plantagents-sync plantagents-sync-manual -n choose-native-plants
+kubectl logs -n choose-native-plants job/plantagents-sync-manual
+```
+
+The schedule is Sunday 07:00 UTC. Failed validation leaves the last active MongoDB snapshot unchanged.
 
 ### Syncing Images
 

--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -3,7 +3,6 @@ app:
     tag: "2.3.1"
   # IMPORTANT: Only include environment variables here that are NOT already defined in the Helm chart template
   # The following environment variables are already defined in the template and should NOT be duplicated here:
-  # - PAC_API_BASE_URL, PAC_API_KEY (from pac-api secret)
   # - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, LINODE_BUCKET_NAME, LINODE_ENDPOINT_URL (from linode-storage secret)
   # Duplicating these variables causes patch errors in the GitOps deployment process
   env:
@@ -14,8 +13,6 @@ app:
         name: app
     - secretRef:
         name: mongo
-    - secretRef:
-        name: pac-api
     - secretRef:
         name: linode-storage
 
@@ -56,3 +53,8 @@ ingress:
       hosts:
         - choosenativeplants.com
         - www.choosenativeplants.com
+
+# Enable after choose-native-plants.secrets/plantagents-postgres.yaml is sealed
+# and a one-off sync has passed sandbox acceptance.
+plantagentsSync:
+  enabled: false


### PR DESCRIPTION
## Summary
- remove legacy pac-api secret injection
- document the PlantAgents PostgreSQL sealed-secret workflow
- add disabled-by-default weekly sync configuration