### PR TITLE
chore(ingress-nginx): remove from projection (#144 phase 5.5)

### DIFF
--- a/.holo/branches/k8s-manifests/_civic-cloud.toml
+++ b/.holo/branches/k8s-manifests/_civic-cloud.toml
@@ -1,4 +1,15 @@
 [holomapping]
 holosource = "=>k8s-blueprint-lke"
-files = "**"
+files = [
+    "**",
+    # ingress-nginx is decommissioned (#144). The exclusion lives here rather
+    # than upstream because cluster-template still ships ingress-nginx for
+    # clusters that haven't migrated.
+    #
+    # Both excludes are required: the first drops the chart input, the second
+    # drops the lens config — without it the helm3 lens errors trying to render
+    # from a now-empty input tree.
+    "!ingress-nginx/**",
+    "!.holo/lenses/ingress-nginx.toml",
+]
 before = "*"


### PR DESCRIPTION
**Draft — blocked. Do not merge yet.** Applying this frees the Linode NodeBalancer at `104.237.148.175`, so any hostname still pointed there dies instantly.

Negative patterns on the civic-cloud holosource, matching what sandbox already does.

## Projection test

```
git diff --name-status origin/deploys/k8s-manifests <projected>
```

**19 deletions, all ingress-nginx, nothing else touched:**

- cluster-scoped: `Namespace`, 2× `ClusterRole`, 2× `ClusterRoleBinding`, `ValidatingWebhookConfiguration`
- namespaced: `Deployment`, `IngressClass`, 2× `Service` (incl. the LoadBalancer), 2× `ServiceAccount`, 2× `Role`, 2× `RoleBinding`, `ConfigMap`, 2× `Job`

Matches #144's prediction exactly.

## This PR is incomplete on its own

11 app `Ingress` objects remain in the projection, because phase 5 (`ingress.enabled: false`) hasn't been done:

```
balancer, browserless-chrome, chime, choose-native-plants, code-for-philly,
echo-http, grafana, sealed-secrets, third-places, vaultwarden (×2)
```

Merged alone, they'd be orphaned against a deleted `IngressClass` — inert, but ingress-shim would keep recreating the failing legacy `<app>-tls` Certificates from their annotations. **Phase 5 should land in this same PR** so the Ingresses and nginx go together.

## Blockers

- [ ] cfp-live-cluster#160 — `balancerproject.org` still on nginx (external DNS, deadline 2026-07-27)
- [ ] cfp-live-cluster#162 — delete browserless-chrome
- [ ] CodeForPhilly/ops#51 — apply the wildcard flip (cuts over third-places)
- [ ] phase 5 — add `ingress.enabled: false` to this PR

Tracked in #164.