### PR TITLE
fix: pin balancer holosource (build is broken) + repair third-places routing

### DIFF
--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -17,5 +17,5 @@ url = "https://github.com/CodeForPhilly/balancer-main.git"
 #     balancer-config, which is not the same thing.)
 #
 # Adopting v1.1.6 means taking the new layout, the ConfigMap, and the HTTPRoute
-# port change together. Tracked in #167. Don't restore a branch ref without it.
+# port change together. Tracked in #168. Don't restore a branch ref without it.
 ref = "c4f28bf2c28eb457ab82d3097f42567ebce9cb1d"

--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,3 +1,21 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
-ref = "refs/heads/main"
+
+# Pinned to a commit, deliberately — not refs/heads/main.
+#
+# balancer-main#517 (v1.1.6) moved balancer to Gateway API upstream and deleted
+# ingress.yaml, which balancer/kustomization.yaml still lists — so tracking main
+# breaks the build outright. v1.1.6 also carries two changes we cannot absorb
+# without matching edits on our side:
+#
+#   - Service port 8000 -> 80, while _gateways/balancer.yaml's HTTPRoute still
+#     targets 8000 — the backend would stop resolving.
+#   - Deployment gains `envFrom: configMapRef: balancer-config`, a ConfigMap
+#     built by upstream's configMapGenerator. Our kustomization doesn't use that
+#     generator, so the ConfigMap wouldn't exist and pods would fail with
+#     CreateContainerConfigError. (We have a *SealedSecret* named
+#     balancer-config, which is not the same thing.)
+#
+# Adopting v1.1.6 means taking the new layout, the ConfigMap, and the HTTPRoute
+# port change together. Tracked in #167. Don't restore a branch ref without it.
+ref = "c4f28bf2c28eb457ab82d3097f42567ebce9cb1d"

--- a/_gateways/third-places.yaml
+++ b/_gateways/third-places.yaml
@@ -31,6 +31,27 @@ spec:
   hostnames:
     - third-places.live.k8s.phl.io
   rules:
-    - backendRefs:
+    # Django serves the API and admin; everything else is the frontend SPA.
+    # Gateway API matches the longest path prefix, so these win over "/" below
+    # regardless of rule order. Mirrors the Ingress this replaced — without the
+    # split, "/" lands on Django and the site 404s.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+        - path:
+            type: PathPrefix
+            value: /admin/
+        - path:
+            type: PathPrefix
+            value: /static/admin/
+      backendRefs:
         - name: third-places
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: third-places-frontend
           port: 80


### PR DESCRIPTION
**The build is broken right now**, and `third-places` is 404ing in production. Two fixes.

## 1. The build is broken — balancer-main deleted its Ingress

```
16:22  last green Build k8s-manifests
16:59  balancer-main#517 merged
17:02  balancer-main main = a8654444 (v1.1.6) — ingress.yaml GONE
```

balancer-main moved to Gateway API upstream and deleted `ingress.yaml` from `deploy/manifests/balancer/base`. Our `balancer/kustomization.yaml` still lists `manifests/ingress.yaml`, and the holosource tracked `refs/heads/main` with no lock. **The next build fails on the missing resource** — reproduced locally, the kustomize lens dies.

## Why pin instead of adopting v1.1.6

The projection diff caught two changes in v1.1.6 that we cannot take piecemeal:

- **Service port `8000` → `80`**, while `_gateways/balancer.yaml`'s HTTPRoute still targets `8000`. The backend would stop resolving.
- **Deployment gains `envFrom: configMapRef: balancer-config`**, built by upstream's `configMapGenerator`. Our kustomization doesn't use that generator, so the ConfigMap wouldn't exist and pods would hit `CreateContainerConfigError`. (We have a *SealedSecret* named `balancer-config` — not the same object.)

Adopting v1.1.6 means taking the new layout, the ConfigMap, and an HTTPRoute port change **together**. That's #167, not a hotfix.

We also do **not** want upstream's `gateway-listeners.yaml`: it declares a `ListenerSet`, and Envoy Gateway v1.7.3 does not reconcile one —

```
XListenerSet CRD not found, skipping XListenerSet watch
```

It would apply cleanly to the API server and be **silently ignored**, leaving the apex with no listener. Revisit at Envoy Gateway v1.8. See #166.

## 2. third-places is 404ing in production

Its HTTPRoute sent **everything** to the Django backend. The Ingress it replaced split traffic:

| path | backend |
|---|---|
| `/` | `third-places-frontend` |
| `/api/`, `/admin/`, `/static/admin/` | `third-places` |

The route was written as a catch-all in phase 3 and never diffed against the Ingress it replaced, so it was **latently wrong for 57 days** and only surfaced when DNS cut over today. Restores the split.

Same class of bug found in `sealed-secrets` (Ingress exposed only `/v1/cert.pem`, HTTPRoute exposes `/`) — tracked separately; not an outage, so not in this PR.

## QA

Projection diff vs `origin/deploys/k8s-manifests` is **exactly one file**:

```
M	third-places/HTTPRoute/third-places.yaml
```

The pin restores the build with **zero** cluster change — no balancer resources move.