### PR TITLE
feat(balancer): app owns the route, cluster owns the Gateway

### DIFF
--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,21 +1,6 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
 
-# Pinned to a commit, deliberately — not refs/heads/main.
-#
-# balancer-main#517 (v1.1.6) moved balancer to Gateway API upstream and deleted
-# ingress.yaml, which balancer/kustomization.yaml still lists — so tracking main
-# breaks the build outright. v1.1.6 also carries two changes we cannot absorb
-# without matching edits on our side:
-#
-#   - Service port 8000 -> 80, while _gateways/balancer.yaml's HTTPRoute still
-#     targets 8000 — the backend would stop resolving.
-#   - Deployment gains `envFrom: configMapRef: balancer-config`, a ConfigMap
-#     built by upstream's configMapGenerator. Our kustomization doesn't use that
-#     generator, so the ConfigMap wouldn't exist and pods would fail with
-#     CreateContainerConfigError. (We have a *SealedSecret* named
-#     balancer-config, which is not the same thing.)
-#
-# Adopting v1.1.6 means taking the new layout, the ConfigMap, and the HTTPRoute
-# port change together. Tracked in #168. Don't restore a branch ref without it.
-ref = "c4f28bf2c28eb457ab82d3097f42567ebce9cb1d"
+# Pinned to a release tag, never a branch. Tracking refs/heads/main is what let
+# balancer-main#517 break this repo's build the moment it merged.
+ref = "refs/tags/v1.1.7"

--- a/_gateways/balancer.yaml
+++ b/_gateways/balancer.yaml
@@ -1,3 +1,15 @@
+# Gateway only. The HTTPRoute lives in balancer-main (v1.1.7+) and is projected
+# through balancer/kustomization.yaml.
+#
+# The split: this cluster decides where the app is reachable — hostname, TLS,
+# issuer, GatewayClass. The app decides what it serves — paths, backends, ports.
+# balancer's route attaches to this Gateway by name and declares no hostnames,
+# so it inherits the listener hostname below and the same file works unchanged in
+# sandbox. See deploy/manifests/balancer/README.md in balancer-main.
+#
+# Do not add an HTTPRoute here. Its backend port would drift the moment the app
+# changed its Service — which is exactly what happened before v1.1.7 (the route
+# said 8000; the app had moved to 80).
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -19,18 +31,3 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: balancer
-  namespace: balancer
-spec:
-  parentRefs:
-    - name: balancer
-  hostnames:
-    - balancerproject.org
-  rules:
-    - backendRefs:
-        - name: balancer
-          port: 8000

--- a/balancer/kustomization.yaml
+++ b/balancer/kustomization.yaml
@@ -3,33 +3,44 @@ kind: Kustomization
 
 namespace: balancer
 
+# balancer-main v1.1.7 owns its own HTTPRoute (paths, backends, ports) and no
+# longer ships an Ingress. This repo owns the Gateway — hostname, TLS, issuer —
+# in _gateways/balancer.yaml. The route attaches to it by name and declares no
+# hostnames, so it inherits the Gateway's listener hostname.
+#
+# We deliberately do not take upstream's gateway-listeners.yaml, and v1.1.7
+# removed it: it declared a ListenerSet, which Envoy Gateway v1.7.3 does not
+# reconcile ("XListenerSet CRD not found, skipping XListenerSet watch"). It
+# would apply cleanly and then be silently ignored.
 resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
   - manifests/service.yaml
-  - manifests/ingress.yaml
+  - manifests/httproute.yaml
 
+# Stays on the running version. v1.1.7 is a deploy-manifest release with no
+# application changes, so bumping the image here would ship app code under cover
+# of a routing change. Bump it deliberately, on its own.
 images:
   - name: ghcr.io/codeforphilly/balancer-main/app
     newTag: "1.1.5"
 
+# v1.1.7's Deployment does `envFrom: configMapRef: balancer-config` alongside the
+# existing `secretRef: balancer-config` (our SealedSecret, holding SECRET_KEY,
+# SQL_*, and the API keys). A ConfigMap and a Secret may share a name.
+#
+# balancer.env is empty upstream, and the app reads ALLOWED_HOSTS rather than
+# HOSTNAME — so this ConfigMap carries nothing. It exists solely so configMapRef
+# resolves; without it the pods fail with CreateContainerConfigError.
+configMapGenerator:
+  - name: balancer-config
+    envs:
+      - manifests/balancer.env
+
+generatorOptions:
+  disableNameSuffixHash: true
+
 patches:
-  - target:
-      kind: Ingress
-      name: balancer
-    patch: |-
-      - op: add
-        path: /metadata/annotations/cert-manager.io~1cluster-issuer
-        value: letsencrypt-prod
-      - op: add
-        path: /metadata/annotations/kubernetes.io~1ingress.class
-        value: nginx
-      - op: replace
-        path: /spec/tls/0/hosts/0
-        value: balancerproject.org
-      - op: replace
-        path: /spec/rules/0/host
-        value: balancerproject.org
   - target:
       kind: Namespace
       name: balancer


### PR DESCRIPTION
Adopts [balancer-main v1.1.7](https://github.com/CodeForPhilly/balancer-main/releases/tag/v1.1.7), which splits routing ownership along what each side can actually know. Closes #168, and supersedes #166.

## The split

| balancer-main owns | this repo owns |
|---|---|
| `HTTPRoute` — paths, backend Services, ports | `Gateway` — hostname, TLS, issuer, `GatewayClass` |

**Paths and ports are app facts.** They change when the app changes and belong in the same commit. Our copy of balancer's route said `port: 8000` while the app had already moved its Service to `80` — under this split, that mismatch cannot happen.

**Hostnames, TLS, and issuers are cluster facts.** They differ per environment and are shared with every other app. balancer-main tried to declare them and got **three of four wrong** — a dead ClusterIssuer, the legacy TLS Secret name, and a `ListenerSet` that Envoy Gateway v1.7.3 silently ignores — because none of them are knowable from that repo.

## The contract

The cluster provides a Gateway named after the app. The app's route attaches by name and declares **no hostnames**, so it inherits the listener's hostname:

```yaml
spec:
  parentRefs:
    - name: balancer
  # no hostnames — inherited
  rules:
    - matches: [{path: {type: PathPrefix, value: /}}]
      backendRefs: [{name: balancer, port: 80}]
```

One file serves `balancerproject.org` here and `balancer.sandbox.k8s.phl.io` in sandbox, with no patches and no placeholders.

**Inheritance was verified against a real Envoy Gateway v1.7.3 before relying on it** — a hostname-less route bound to sandbox's `echo-http` Gateway with `Accepted=True` and served on the listener's hostname (200). Given that a `ListenerSet` applies cleanly and is then silently ignored, I wasn't willing to take the spec's word for it.

## Also in this PR

- **Pins the holosource to `refs/tags/v1.1.7`, never a branch.** Tracking `refs/heads/main` is exactly what let balancer-main#517 break this repo's build the moment it merged.
- **Generates the (empty) `balancer-config` ConfigMap** that v1.1.7's Deployment expects via `configMapRef`, alongside the existing SealedSecret of the same name (a ConfigMap and a Secret may share a name). Without it, pods `CreateContainerConfigError`. `balancer.env` is empty upstream and the app reads `ALLOWED_HOSTS`, not `HOSTNAME`.
- **Drops the Ingress**, now that `balancerproject.org` resolves to the Envoy LB and `balancer-gw-tls` has issued.
- **Leaves the app image on `1.1.5`.** v1.1.7 is a deploy-manifest release with no application changes; bumping the image here would ship app code under cover of a routing change.

## QA

```
A	balancer/ConfigMap/balancer-config.yaml     (new, empty — satisfies configMapRef)
M	balancer/Deployment/balancer.yaml           (+configMapRef only; image unchanged)
M	balancer/HTTPRoute/balancer.yaml            (app-owned: no hostnames, port 80)
D	balancer/Ingress/balancer.yaml
M	balancer/Service/balancer.yaml              (port 80 -> targetPort 8000)
M	third-places/HTTPRoute/third-places.yaml    (already applied to cluster; deploys branch catching up)
```

Deployment delta is **only** the `configMapRef` line.