### PR TITLE
Deploy Choose Native Plants v2.3.3 to live

### DIFF
--- a/.holo/sources/choose-native-plants.toml
+++ b/.holo/sources/choose-native-plants.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/pa-wildflower-selector"
-ref = "refs/tags/v2.3.1"
+ref = "refs/tags/v2.3.3"

--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,6 +1,6 @@
 app:
   image:
-    tag: "2.3.1"
+    tag: "2.3.3"
   # IMPORTANT: Only include environment variables here that are NOT already defined in the Helm chart template
   # The following environment variables are already defined in the template and should NOT be duplicated here:
   # - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, LINODE_BUCKET_NAME, LINODE_ENDPOINT_URL (from linode-storage secret)


### PR DESCRIPTION
Updates both required Choose Native Plants live release pins:\n\n- Chart source: refs/tags/v2.3.3\n- Application image: 2.3.3\n\nSandbox verification completed successfully:\n- Deployment healthy on 2.3.3\n- Nursery map endpoint returns HTTP 200\n- ALL-state API returns 528 nurseries\n- PlantAgents sync status is successful\n\nThis release includes the PlantAgents local snapshot cutover and the nursery-map fixes for ALL-state filtering, missing coordinates, and missing contact fields.