### PR TITLE
Run one-off Choose Native Plants production data sync

### DIFF
--- a/choose-native-plants.plantagents-sync-20260714.yaml
+++ b/choose-native-plants.plantagents-sync-20260714.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plantagents-sync-20260714-v233
+  namespace: choose-native-plants
+  labels:
+    app.kubernetes.io/name: choose-native-plants
+    app.kubernetes.io/component: plantagents-sync
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: choose-native-plants
+        app.kubernetes.io/component: plantagents-sync
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: plantagents-sync
+          image: ghcr.io/codeforphilly/pa-wildflower-selector/app:2.3.3
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              npm run sync:plantagents -- --dry-run
+              npm run sync:plantagents
+          env:
+            - name: DB_HOST
+              value: choose-native-plants
+            - name: DB_PORT
+              value: "27017"
+            - name: DB_NAME
+              value: pa-wildflower-selector
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mongo
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo
+                  key: password
+            - name: PLANTAGENTS_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: plantagents-postgres
+                  key: PLANTAGENTS_DATABASE_URL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi


### PR DESCRIPTION
Adds a one-off production Job for the PlantAgents snapshot cutover.\n\nSafety behavior:\n- Uses the deployed v2.3.3 image\n- Runs a non-publishing dry-run first\n- Runs the real atomic publish only if validation succeeds\n- Uses the existing read-only plantagents-postgres secret\n- Disables retries with backoffLimit: 0\n\nAfter the Job succeeds and the live API is verified, this manifest will be removed in a cleanup PR.