### PR TITLE
feat(prometheus): alert on certificate expiry, stuck renewal, and stuck challenges

### DIFF
--- a/prometheus/release-values.yaml
+++ b/prometheus/release-values.yaml
@@ -1,0 +1,99 @@
+# These values are applied last as downstream overrides
+# See https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
+
+# Certificate alerting.
+#
+# These rules exist because of the 2026-07-12 outage (#144, #163): nine certificates
+# expired simultaneously and it was invisible for 56 days. cert-manager logged nothing,
+# the Certificates reported Ready=True right up until the moment they expired, and the
+# first signal anyone got was a user hitting a browser warning.
+#
+# The metrics were there the whole time. Nobody was watching them.
+#
+# These are generic — they belong in cluster-template, not here, and are proposed
+# upstream in JarvusInnovations/cluster-template. Keep them here until that lands, then
+# drop them and leave only the receiver config below.
+serverFiles:
+  alerting_rules.yml:
+    groups:
+      - name: cert-manager
+        rules:
+          # THE ONE THAT WOULD HAVE CAUGHT JULY.
+          #
+          # A Certificate stays Ready=True while it is valid, so readiness tells you
+          # nothing until it's already too late. What actually happened is that
+          # renewalTime passed and nothing renewed — silently, for 30 days.
+          #
+          # status.renewalTime jumps forward on a successful renewal. If it is more than
+          # a day in the past, renewal is stuck. This fires ~29 days before expiry, while
+          # there is still plenty of time to fix it.
+          - alert: CertManagerCertRenewalOverdue
+            expr: (time() - certmanager_certificate_renewal_timestamp_seconds) > 86400
+            for: 1h
+            labels:
+              severity: warning
+            annotations:
+              summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} is overdue for renewal"
+              description: >-
+                Renewal was scheduled {{ $value | humanizeDuration }} ago and has not
+                happened. The certificate is probably still valid, so nothing looks
+                broken yet — that is exactly how the July 2026 outage stayed invisible
+                for 56 days. Check `kubectl get challenges -A` for a stuck challenge
+                holding this hostname's slot.
+
+          # Any challenge that lingers is abnormal — a healthy HTTP-01 completes in
+          # seconds. A challenge pending for an hour means something is wrong; one
+          # pending for days is the deadlock that caused the outage (a half-orphaned
+          # Challenge holds its dnsName's scheduler slot forever, and cert-manager will
+          # not run two challenges for the same dnsName concurrently).
+          - alert: CertManagerChallengeStuck
+            expr: certmanager_certificate_challenge_status == 1
+            for: 1h
+            labels:
+              severity: warning
+            annotations:
+              summary: "ACME challenge stuck for {{ $labels.namespace }}/{{ $labels.name }}"
+              description: >-
+                Challenge has been in flight for over an hour ({{ $labels.status }}).
+                Healthy challenges resolve in seconds. If its Order is already gone, the
+                Challenge is a half-orphan — Kubernetes GC will not reap it, because it
+                also has an owner ref to the ClusterIssuer — and it must be deleted by
+                name or it will starve every future renewal for this hostname.
+
+          # Backstop. Renewal begins at 30 days out, so 21 days means renewal has been
+          # failing for over a week.
+          - alert: CertManagerCertExpiringSoon
+            expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < (21 * 86400)
+            for: 1h
+            labels:
+              severity: warning
+            annotations:
+              summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }}"
+              description: "Renewal starts at 30 days, so this has been failing for a week or more."
+
+          - alert: CertManagerCertExpiringCritical
+            expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < (7 * 86400)
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }}"
+              description: "Under a week to expiry. Users will see browser warnings when this lapses."
+
+          - alert: CertManagerCertNotReady
+            expr: certmanager_certificate_ready_status{condition="True"} == 0
+            for: 1h
+            labels:
+              severity: warning
+            annotations:
+              summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+              description: "Issuance has been failing for over an hour."
+
+          - alert: CertManagerClusterIssuerNotReady
+            expr: certmanager_clusterissuer_ready_status{condition="True"} == 0
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              summary: "ClusterIssuer {{ $labels.name }} is not Ready"
+              description: "No certificate can be issued or renewed through this issuer."


### PR DESCRIPTION
Part of #163. **The cluster currently has zero alert rules** — `alerting_rules.yml` is literally `{}`.

## Why this is the actual fix for July

The metrics were there the whole time. Prometheus has been scraping cert-manager all along — 27 series of `certmanager_certificate_expiration_timestamp_seconds` are live right now. Nobody was watching them.

Nine certificates expired on 2026-07-12 and it was invisible for **56 days**. cert-manager logged nothing, and — this is the part that matters for alert design — **the Certificates reported `Ready=True` right up until the moment they expired.** A readiness alert would have caught nothing.

What actually happened is that `renewalTime` passed and nothing renewed. That's the signal, and it's the first rule here.

## The rules

**`CertManagerCertRenewalOverdue`** — the one that would have caught this.

```promql
(time() - certmanager_certificate_renewal_timestamp_seconds) > 86400
```

`status.renewalTime` jumps forward on a successful renewal, so if it's more than a day in the past, renewal is stuck. **This fires ~29 days before expiry**, while the cert is still perfectly valid and nothing looks broken — which is exactly the window we slept through.

**`CertManagerChallengeStuck`** — the deadlock detector.

```promql
certmanager_certificate_challenge_status == 1   # for: 1h
```

A healthy HTTP-01 challenge completes in seconds. One pending for an hour is wrong; one pending for 56 days is the deadlock that caused the outage — a half-orphaned Challenge (owner-ref'd to both its Order *and* the ClusterIssuer, so GC won't reap it) holding its dnsName's scheduler slot forever, while cert-manager refuses to run two challenges for the same dnsName.

Plus backstops: `CertManagerCertExpiringSoon` (21d), `CertManagerCertExpiringCritical` (7d), `CertManagerCertNotReady`, `CertManagerClusterIssuerNotReady`.

## Validated

```
$ promtool check rules rules.yml
  SUCCESS: 6 rules found
```

Projection diff is one file — `M prometheus/ConfigMap/prometheus-server.yaml` — and I confirmed all six alerts render into `alerting_rules.yml`.

## These belong upstream, not here

They're generic — a certificate expiring is a problem in *any* cluster. `k8s-common/prometheus/default-values.yaml` in cluster-template is "applied first as template-provided defaults", which is exactly the right home. I'm proposing them there separately; once that lands and civic-cloud picks it up, this file drops the rules and keeps only the receiver.

The split follows the same principle as the routing work: **the template owns what a problem *is*; the cluster owns where to *send* it.**

## Still missing: somewhere for alerts to go

Alertmanager's only receiver is `default-receiver` with **no configuration** — a black hole. With this PR alerts become visible in Prometheus and Grafana, but nothing is pushed to a human.

Closing that needs a credential I can't create:
- **Slack** — needs an incoming webhook URL (the existing `code-for-philly/slack` secret is the *site's* OAuth app token, not a webhook — wrong thing to reuse)
- **Email** — could use the Postmark SMTP creds, sealed into the `prometheus` namespace, sending to `services@codeforphilly.org` (already cert-manager's ACME contact)

Tracked in #163.