### PR TITLE
feat(infra): install CloudNativePG operator and shared-cluster

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -140,7 +140,7 @@ Things not in any single grep-able file:
 - **Wildcard DNS**: `*.live.k8s.phl.io` → the Envoy LB `45.79.246.168`. DNS is managed in OpenTofu at [CodeForPhilly/ops](https://github.com/CodeForPhilly/ops) → `tofu/dns`; a host with no specific record simply follows the wildcard, so new apps need no DNS change at all.
 - **Apex domains in tree**: `balancerproject.org`, `choosenativeplants.com` (+ `www.`), `codeforphilly.org` (+ `www.`), `penn-chime.phl.io`, `vaultwarden.phl.io`, `bitwarden.phl.io`. Apex ACME challenges only work once DNS points at Envoy — plan cutover and cert issuance together for these. `choosenativeplants.com` is at **Namecheap**, not Cloud DNS, so it can't be moved from the ops repo.
 - **A new hostname is briefly down between DNS and cert.** The cert can't issue until the hostname resolves to Envoy (Let's Encrypt has to reach the solver), and Envoy's HTTPS listener doesn't program until the cert Secret exists — meanwhile HTTP 301s into a listener that isn't there. Roughly 60–90s. Keep TTLs at 60s.
-- **No cnpg / shared-cluster** on this cluster yet. If a database is needed, it ships per-app (e.g. vaultwarden runs its own PostgreSQL StatefulSet via the gissilabs chart; chime + third-places similar).
+- **cnpg is landing.** `_infra/cloudnative-pg/` installs the operator (chart v0.28.0) and a `shared-cluster` Cluster, mirroring cfp-sandbox-cluster. It has **no backup configuration** — do not let it hold the only copy of anything until an object store lands (CodeForPhilly/balancer-main#526). Existing apps still ship their own database per-app (vaultwarden runs a PostgreSQL StatefulSet via the gissilabs chart; chime + third-places similar); nothing has been migrated onto the shared cluster yet.
 
 ## Guardrails
 

--- a/.holo/branches/k8s-manifests/_infra/cloudnative-pg/operator.toml
+++ b/.holo/branches/k8s-manifests/_infra/cloudnative-pg/operator.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "cloudnative-pg-chart"
+root = "charts/cloudnative-pg"
+files = "**"

--- a/.holo/lenses/cloudnative-pg.toml
+++ b/.holo/lenses/cloudnative-pg.toml
@@ -1,0 +1,14 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.input]
+root = "_infra/cloudnative-pg/operator"
+files = "**"
+
+[hololens.output]
+merge = "replace"
+
+[hololens.helm]
+namespace = "cloudnative-pg"
+release_name = "cloudnative-pg"
+include_crds = true

--- a/.holo/sources/cloudnative-pg-chart.toml
+++ b/.holo/sources/cloudnative-pg-chart.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/cloudnative-pg/charts.git"
+ref = "refs/tags/cloudnative-pg-v0.28.0"

--- a/_infra/cloudnative-pg/namespaces.yaml
+++ b/_infra/cloudnative-pg/namespaces.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudnative-pg

--- a/_infra/cloudnative-pg/shared-cluster.yaml
+++ b/_infra/cloudnative-pg/shared-cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: shared-cluster
+  namespace: cloudnative-pg
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgis:18-3-system-trixie
+
+  storage:
+    # Explicit, unlike sandbox, which takes the cluster default. `-retain` keeps
+    # the Linode volume if the PVC is ever deleted — on this cluster that is the
+    # difference between an incident and an outage.
+    storageClass: linode-block-storage-retain
+    size: 20Gi
+
+  # No `managed.roles` yet: the balancer role's passwordSecret has to be sealed
+  # into cloudnative-pg.secrets/ first, and cnpg reports a role reconcile error
+  # for as long as the Secret it names is absent. The role and the balancer
+  # Database CR land together in the follow-up PR.
+  #
+  # No `backup:` stanza yet either — it needs an object store bucket plus
+  # credentials that do not exist. This cluster must not hold the only copy of
+  # production data until that lands. See CodeForPhilly/balancer-main#526.


### PR DESCRIPTION
Step 4 of CodeForPhilly/balancer-main#526 — stand up CloudNativePG on this cluster. **Nothing cuts over here.** Production Balancer keeps reading from AWS RDS; this only puts the destination cluster in place beside it.

Opened as a draft: this adds a shared-infra component to the live cluster and wants @themightychris's eyes before it merges.

## What lands

| Path | What |
|---|---|
| `.holo/sources/cloudnative-pg-chart.toml` | chart source, pinned `refs/tags/cloudnative-pg-v0.28.0` |
| `.holo/branches/k8s-manifests/_infra/cloudnative-pg/operator.toml` | projects `charts/cloudnative-pg` → `_infra/cloudnative-pg/operator` |
| `.holo/lenses/cloudnative-pg.toml` | helm3 lens, `include_crds = true`, release `cloudnative-pg` in ns `cloudnative-pg` |
| `_infra/cloudnative-pg/namespaces.yaml` | the namespace |
| `_infra/cloudnative-pg/shared-cluster.yaml` | `Cluster/shared-cluster`, 2 instances, PostGIS 18 image, 20Gi |
| `.claude/CLAUDE.md` | the "No cnpg / shared-cluster on this cluster yet" bullet is no longer true |

All of it mirrors `cfp-sandbox-cluster`, which has been running this exact shape since June. The Cluster CR and namespace sit *outside* the lens input root, so they pass through raw while the chart gets rendered.

## Two deliberate omissions

**No `managed.roles`.** The `balancer` role names a `passwordSecret` that has to be sealed into `cloudnative-pg.secrets/` first — and cnpg reports a role reconcile error for as long as that Secret is absent. The role and the `Database` CR land together in the follow-up PR, after the seal.

**No `backup:` stanza.** It needs an object store bucket and credentials that do not exist yet. Worth stating plainly: **this cluster has no backups, and neither does sandbox.** Moving production data here before that lands would trade RDS's automated snapshots for nothing. That is tracked as a blocking step in CodeForPhilly/balancer-main#526.

## One difference from sandbox

`storageClass: linode-block-storage-retain` is explicit here; sandbox takes the cluster default. On a production cluster the `-retain` reclaim policy is the difference between a deleted PVC being an incident and being an outage. Flagging it since it is the one line not copied verbatim.

## Verification after deploy

```
kubectl -n cloudnative-pg get pods                    # operator Running, shared-cluster-1/-2 Running
kubectl -n cloudnative-pg get cluster shared-cluster  # STATUS: Cluster in healthy state
kubectl get crd | grep cnpg                           # clusters, databases, backups, poolers...
kubectl -n cloudnative-pg exec shared-cluster-1 -- psql -tAc "select version()"
```

No existing workload is touched — no app in this repo references cnpg yet.

## Sequencing

1. **this PR** — operator + empty cluster
2. seal `balancer-db-credentials` into `cloudnative-pg.secrets/` (needs cluster access; not a PR I can open)
3. follow-up PR — `managed.roles` + `balancer/cnpg/database.yaml` with the `vector` extension, plus the `balancer/` split into `app/` + `cnpg/` that sandbox already has
4. `pg_dump` RDS → `pg_restore` → row-count parity check
5. re-seal `balancer.secrets/balancer-config.yaml` with the cnpg host, bump the image off `1.1.5`
6. object store + `ScheduledBackup`, then decommission RDS

Steps 2, 4 and 5 need cluster and AWS credentials, so they cannot be delivered as PRs.
