### PR TITLE
chore(vaultwarden): bump app image to v1.37.2

### DIFF
--- a/vaultwarden/release-values.yaml
+++ b/vaultwarden/release-values.yaml
@@ -4,7 +4,7 @@
 
 # override version until https://github.com/gissilabs/charts/issues/31
 image:
-  tag: 1.36.0
+  tag: 1.37.2
 
 # Routing is handled by Envoy Gateway — see _gateways/vaultwarden.yaml.
 # vaultwarden.domain below is set explicitly, so DOMAIN survives this.


### PR DESCRIPTION
Bumps vaultwarden `1.36.0` → `1.37.2`.

## Why

Bitwarden clients auto-update, and 1.36.0 can no longer serve current ones:

- **1.37.0** — required for clients `v2026.7.0+`
- **1.37.2** — required for clients `v2026.8.0+`

Symptom is login failure from the browser extension against an out-of-date server (upstream [discussion #7615](https://github.com/dani-garcia/vaultwarden/discussions/7615)). `vaultwarden.phl.io` is currently serving 1.36.0.

1.37.0 also carries eight medium-severity security fixes: SSRF via the icon endpoint, cross-organization cipher access, org policy bypass on directory import, Send access-count bypass, unauthenticated WebSocket flooding DoS, cross-org secret sharing, org import authorization, and org data enumeration via the Manager role.

## Before merging — please read

**Migrations are one-way.** Vaultwarden runs schema migrations on startup and does not support downgrade. Reverting this commit will *not* roll the deployment back; that requires restoring the database from a restic snapshot.

Backups were validated against the live repo before opening this:

- Latest DB snapshot `f5440783` (2026-08-25 15:40 UTC), 213.6 KiB gz, gzip stream intact, terminates with `PostgreSQL database cluster dump complete` (i.e. `pg_dumpall` ran to completion).
- 58 users / 110 ciphers / 12 organizations; all 110 cipher rows carry Bitwarden ciphertext.
- All 16 attachment cipher UUIDs in the DB match the 16 attachment directories in the `/data` snapshot exactly — no orphans in either direction. `rsa_key.pem` / `.pub.pem` are captured, so JWT signing keys survive a restore.

Not verified: the dump has never been replayed into a live Postgres, and no `restic check` has been run against the repo.

## Watch after rollout

1.37.0 adds per-IP rate limiting on unauthenticated endpoints. We route through Envoy Gateway, which sets `x-forwarded-for`, while vaultwarden's `IP_HEADER` defaults to `x-real-ip` — and we don't set it. If vaultwarden can't resolve real client IPs it will bucket all unauthenticated traffic together. Worth watching the logs for client-IP warnings and setting `IP_HEADER` if they appear.

Expect a brief outage on deploy: the RWO attachment PVC forces `strategy: Recreate`. Users may also be logged out and need their master password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSNAVVDuF46SMHjnyfmxwU