### PR TITLE
chore(envoy-gateway): exclude certgen hook Job from projected manifests

### DIFF
--- a/.holo/branches/k8s-manifests/_civic-cloud.toml
+++ b/.holo/branches/k8s-manifests/_civic-cloud.toml
@@ -11,5 +11,19 @@ files = [
     # from a now-empty input tree.
     "!ingress-nginx/**",
     "!.holo/lenses/ingress-nginx.toml",
+
+    # certgen.yaml is a Helm `pre-install,pre-upgrade` hook Job that generates
+    # the envoy-gateway webhook certs. `helm template` emits hooks like any
+    # other manifest (the helm3 lens has no --no-hooks), so it lands in the
+    # projection and gets kubectl-applied on every deploy.
+    #
+    # It carries `ttlSecondsAfterFinished: 30`, so it deletes itself moments
+    # after running. `kubectl diff` therefore reports it as a fresh creation in
+    # EVERY deploy PR, which buries real changes in recurring noise.
+    #
+    # Dropping the template excludes the Job while leaving certgen-rbac.yaml in
+    # place, so re-enabling it is a one-line revert. The certs it generated are
+    # valid until 2031-05-17 and it does not rotate existing ones.
+    "!envoy-gateway/helm-chart/templates/certgen.yaml",
 ]
 before = "*"


### PR DESCRIPTION
Stops the envoy-gateway certgen Job from appearing as recurring drift in every deploy PR.

## Problem

The gateway-helm chart ships `certgen.yaml` as a Helm `pre-install,pre-upgrade` hook that generates the envoy-gateway webhook certs. `helm template` emits hooks like any other manifest, and the helm3 hololens has no `--no-hooks` option — so the Job lands in the projection and gets `kubectl apply`'d on every deploy.

It carries `ttlSecondsAfterFinished: 30`, so it deletes itself moments after running. `kubectl diff` therefore reports it as a **fresh creation in every deploy PR**, forever. It appeared alongside the vaultwarden bump in #185 and in #181 before that, and each occurrence has to be re-triaged by hand to confirm it's benign — which is exactly the kind of standing noise that erodes the diff gate's value as a review surface.

## Fix

Exclude the chart template so the Job is dropped *before* helm renders it. This mirrors the `!templates/tests/**` exclusion already used for the vaultwarden chart, and sits next to the existing ingress-nginx exclusion in the same mapping.

`certgen-rbac.yaml` is deliberately left in place, so re-enabling this is a one-line revert.

## Why it's safe to drop

- **It doesn't rotate existing certs.** It re-ran during #181 a month ago, yet the `envoy` and `envoy-gateway` secrets still date to 2026-05-18 — it only creates certs when missing.
- **The certs it generated are valid until 2031-05-17.**
- Applying a Helm lifecycle hook declaratively was never really correct; hooks are meant to run under Helm's install/upgrade lifecycle, not be reconciled by `kubectl apply`.

Should this cluster ever need certgen again (cert loss, a from-scratch rebuild), reverting this line restores it.

## Verification

Ran `git holo project k8s-manifests` locally against this branch. The only delta versus the currently deployed tree:

```
D  envoy-gateway-system/Job/envoy-gateway-gateway-helm-certgen.yaml
```

The certgen RBAC (`ClusterRole`, `ClusterRoleBinding`, `Role`, `RoleBinding`, `ServiceAccount`) is retained as intended, and nothing else in the projection moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSNAVVDuF46SMHjnyfmxwU